### PR TITLE
Added blacklist to prevent lava from destroying blocks.

### DIFF
--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/WorldConfiguration.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/WorldConfiguration.java
@@ -98,6 +98,7 @@ public class WorldConfiguration {
     public boolean ropeLadders;
     public boolean allowPortalAnywhere;
     public Set<Integer> preventWaterDamage;
+    public Set<Integer> preventLavaDamage;
     public boolean blockLighter;
     public boolean disableFireSpread;
     public Set<Integer> disableFireSpreadBlocks;
@@ -382,6 +383,7 @@ public class WorldConfiguration {
         ropeLadders = getBoolean("physics.vine-like-rope-ladders", false);
         allowPortalAnywhere = getBoolean("physics.allow-portal-anywhere", false);
         preventWaterDamage = new HashSet<Integer>(getIntList("physics.disable-water-damage-blocks", null));
+        preventLavaDamage = new HashSet<Integer>(getIntList("physics.disable-lava-damage-blocks", null));
 
         blockTNTExplosions = getBoolean("ignition.block-tnt", false);
         blockTNTBlockDamage = getBoolean("ignition.block-tnt-block-damage", false);

--- a/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardBlockListener.java
+++ b/worldguard-legacy/src/main/java/com/sk89q/worldguard/bukkit/listener/WorldGuardBlockListener.java
@@ -176,6 +176,18 @@ public class WorldGuardBlockListener implements Listener {
             }
         }
 
+        // Check the fluid block (from) whether it is air.
+        // If so and the target block is protected, cancel the event
+        if (wcfg.preventLavaDamage.size() > 0) {
+            int targetId = blockTo.getTypeId();
+
+            if ((isAir || isLava) &&
+                    wcfg.preventLavaDamage.contains(targetId)) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+
         if (wcfg.allowedLavaSpreadOver.size() > 0 && isLava) {
             int targetId = blockTo.getRelative(0, -1, 0).getTypeId();
 


### PR DESCRIPTION
Added a new list to the config "physics.disable-lava-damage-blocks" and extended the BlockFromToEvent listener with a check for this blacklist.